### PR TITLE
Add Sayella to the apps supporting OBF

### DIFF
--- a/app/views/docs/index.html.erb
+++ b/app/views/docs/index.html.erb
@@ -285,6 +285,17 @@
           </tr>
           <tr>
             <td>
+              <a href="https://sayella.com" target="_blank">
+                <img src="https://is1-ssl.mzstatic.com/image/thumb/Purple221/v4/99/df/cf/99dfcf6c-fe72-14a5-5b17-9e9b11cbf397/AppIcon-0-0-1x_U007epad-0-1-85-220.png/80x80bb.png" style="display: inline-block; width: 40px;"/>
+                {{t "Sayella" key='sayella'}}
+              </a>
+            </td>
+            <td>{{t "native .obf/.obz import and export" key='obf_import_export'}}</td>
+            <td>{{t "Sayella is an affordable AAC app for iPhone and iPad, made in the UK, with a free tier whose speech is never disabled." key='sayella_explainer'}}</td>
+            <td>{{t "July 2026" key='jul_2026'}}</td>
+          </tr>
+          <tr>
+            <td>
               <a href="http://www.theopenvoicefactory.org/" target="_blank">
               <img src="Key-logo-600x200.png" style="display: inline-block; width: 40px; visibility: hidden;"/>
               {{t "The Open Voice Factory" key='open_voice_factory'}}


### PR DESCRIPTION
Hi! Sayella (https://sayella.com) is a new AAC app for iPhone and iPad, made in the UK, that launched on the App Store this month with native .obf/.obz import and export.

We built OBF support in from day one because we think families should never be locked into a vendor: vocabularies come in from other OBF apps and leave just as freely.

This PR adds a row to the supporting-apps table, following the existing format. App Store link for verification: https://apps.apple.com/app/sayella-aac-speech-app/id6782873891

Happy to adjust anything about the entry, and thank you for maintaining the format and this site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)